### PR TITLE
efficiency changes

### DIFF
--- a/build_mpc.jl
+++ b/build_mpc.jl
@@ -1,0 +1,95 @@
+#=
+author: Linh Pham Thi
+created on: 20.12.2019
+
+This function uses the Ipopt and JuMP packages to solve a non-linear optimization problem. This problem is formulated in the classical MPC form. This is a state reference follower control.
+=#
+
+using Ipopt, JuMP, LinearAlgebra
+
+struct MPCSolver
+
+    model        #JuMP model
+    xvar         #[4,N] array of JuMP variables for the state
+    uvar         #[4,N] array of JuMP variables for the inputs
+    xref_param   #[4,N] array of JuMP parameters for the state reference trajectory
+    xinit_param  #4 element array of JuMP parameters for the initial state x0
+    uprev_param  #2 element array of JuMP parameters for the previous input u_{-1}
+
+end
+
+
+function build_mpc(horizon_length)
+
+    # Parameters
+    delta_t = 0.1
+
+    Q = Diagonal(vec(ones(1,4)))         # Weighting matrix for states
+    Q[3,3] = 0  # Set penalty of heading angle to zero due to not knowing reference
+    R = Diagonal(vec(fill(4,2)))       # Weighting matrix for inputs
+
+    # Steering slip - negative for oversteer, positive for understeer
+    C1 = 0.5
+    # Steering angle coupling - radians turned / meter travelled
+    C2 = 15
+    # Duty cycle to acceleration a = Cm1 * throttle
+    Cm1 = 19.6
+    # Cm2 = Cm1 / v_motor_max (i.e. max speed with no air resistance)
+    Cm2 = 14.2
+    # Rolling resistance
+    Cr1 = 1.8
+    # Reduced air resistance coefficient (0.5 * rho * A * C_d)
+    Cr2 = 0.0045
+
+    model = Model(with_optimizer(Ipopt.Optimizer,
+    max_cpu_time=60.0,
+    print_level=0,
+    derivative_test = "none",
+    hessian_approximation = "exact",
+    print_options_documentation="no",
+    print_user_options="no"))#, acceptable_tol= 10^-3)) #, print_level=0))
+
+
+    # Variables
+    @variable(model, x[1:4, 1:horizon_length])
+    @variable(model, u[1:2, 1:horizon_length])
+
+    #Parameters
+    @NLparameter(model, xref[i=1:4, j=1:horizon_length] == 0.0)
+    @NLparameter(model, xinit[i=1:4] == 0.0)
+    @NLparameter(model, uprev[i=1:2] == 0.0)
+
+    #package model and its variables/parameters into a struct
+    mpcsolver = MPCSolver(model,x,u,xref,xinit,uprev)
+
+    # Initial conditions
+    @NLconstraint(model, [j=1:4], x[j,1] == xinit[j])
+
+    # Bounds for input and speed
+    @constraint(model, [i=1:horizon_length], 0<=(u[1,i])<=1)
+    @constraint(model, [i=1:horizon_length], -1<=(u[2,i])<=1)
+    @constraint(model, [i=1:horizon_length], x[4,i]>=0)
+
+
+    # Dynamic constraints (bicycle model)
+    @NLconstraint(model, [i=2:horizon_length],
+    x[1,i] == x[1, i-1] + (x[4, i-1] * cos(x[3, i-1]+C1 * u[2, i-1])*delta_t))
+    @NLconstraint(model, [i=2:horizon_length],
+    x[2,i] == x[2, i-1] + (x[4, i-1] * sin(x[3, i-1]+C1 * u[2, i-1]))*delta_t)
+    @NLconstraint(model, [i=2:horizon_length],
+    x[3,i] == x[3, i-1] + (C2 * u[2, i-1] * x[4, i-1])*delta_t)
+    @NLconstraint(model, [i=2:horizon_length],
+    x[4,i] == x[4, i-1] + (Cm1 * u[1,i-1] - Cm2 * u[1,i-1] * x[4,i-1] - Cr2 * x[4, i-1] * x[4, i-1])* delta_t - Cr1*delta_t)
+
+    # TODO: add track boundary constaints
+
+    # Setting objective function
+    @NLobjective(model, Min,
+    sum(Q[j,j]*(x[j,i]-xref[j,i])^2 for i in 1:settings.horizon_length for j in 1:4) +
+    sum(R[j,j]*(u[j,i]-u[j,i-1])^2 for i in 2:settings.horizon_length for j in 1:2) +
+    sum(R[j,j]*(u[j,1]-uprev[j])^2 for j in 1:2))
+
+    JuMP.optimize!(model)
+
+    return mpcsolver
+end

--- a/run_mpc.jl
+++ b/run_mpc.jl
@@ -7,77 +7,52 @@ This function uses the Ipopt and JuMP packages to solve a non-linear optimizatio
 
 using Ipopt, JuMP, LinearAlgebra
 
-function run_mpc(x_ref, x, u_last, x_plan_prev, horizon_length)
+function warm_start(mpcsolver, x_plan_prev, u_plan_prev, N)
 
-    # Parameters
-        delta_t = 0.1
-        x_current = x
-
-        Q = Diagonal(vec(ones(1,4)))         # Weighting matrix for states
-        Q[3,3] = 0  # Set penalty of heading angle to zero due to now knowing reference
-        R = Diagonal(vec(fill(4,2)))       # Weighting matrix for inputs
-
-        # Steering slip - negative for oversteer, positive for understeer
-        C1 = 0.5
-        # Steering angle coupling - radians turned / meter travelled
-        C2 = 15
-        # Duty cycle to acceleration a = Cm1 * throttle
-        Cm1 = 19.6
-        # Cm2 = Cm1 / v_motor_max (i.e. max speed with no air resistance)
-        Cm2 = 14.2
-        # Rolling resistance
-        Cr1 = 1.8
-        # Reduced air resistance coefficient (0.5 * rho * A * C_d)
-        Cr2 = 0.0045
-
-    model = Model(with_optimizer(Ipopt.Optimizer, max_cpu_time=60.0, print_level=0))#, acceptable_tol= 10^-3)) #, print_level=0))
-
-    # Variables
-        @variable(model, x[1:4, 1:horizon_length])
-        @variable(model, u[1:2, 1:horizon_length])
-
-
-    # Warm start
-        for i = 1:horizon_length
-            for j=1:4
-                set_start_value(x[j,i], x_plan_prev[j,2])
-            end
-
-            for j=1:2
-                set_start_value(u[j,i], u_last[j])
-            end
+    # Warm start state trajectory
+    for i = 1:(N-1)
+        for j=1:4
+            set_start_value(mpcsolver.xvar[j,i], x_plan_prev[j,i+1])
         end
-
-
-    # Initial conditions
-        @constraint(model, [j=1:4], x[j,1] == x_current[j])
-
-    # Bounds for input and speed
-        @constraint(model, [i=1:horizon_length], 0<=(u[1,i])<=1)
-        @constraint(model, [i=1:horizon_length], -1<=(u[2,i])<=1)
-
-        @constraint(model, [i=1:horizon_length], x[4,i]>=0)
-
-
-    # Dynamic constraints (bicycle model)
-    @NLconstraint(model, [i=2:horizon_length],
-                    x[1,i] == x[1, i-1] + (x[4, i-1] * cos(x[3, i-1]+C1 * u[2, i-1])*delta_t))
-    @NLconstraint(model, [i=2:horizon_length],
-                    x[2,i] == x[2, i-1] + (x[4, i-1] * sin(x[3, i-1]+C1 * u[2, i-1]))*delta_t)
-    @NLconstraint(model, [i=2:horizon_length],
-                    x[3,i] == x[3, i-1] + (C2 * u[2, i-1] * x[4, i-1])*delta_t)
-    @NLconstraint(model, [i=2:horizon_length],
-            x[4,i] == x[4, i-1] + (Cm1 * u[1,i-1] - Cm2 * u[1,i-1] * x[4,i-1] - Cr2 * x[4, i-1] * x[4, i-1])* delta_t - Cr1*delta_t)
-
-    # TODO: add track boundary constaints
-
-    # Setting objective function
-    @NLobjective(model, Min,
-            sum(Q[j,j]*(x[j,i]-x_ref[j,i])^2 for i in 1:settings.horizon_length for j in 1:4) +
-            sum(R[j,j]*(u[j,i]-u[j,i-1])^2 for i in 2:settings.horizon_length for j in 1:2) +
-            sum(R[j,j]*(u[j,1]-u_last[j])^2 for j in 1:2))
-
-        JuMP.optimize!(model)
-
-        return JuMP.value.(x), JuMP.value.(u)[:,1]
     end
+
+    #extend previous planning horizon by one
+    xNp1 = simulation(x_plan_prev[:,N], u_plan_prev[:,N])
+    for j=1:4
+        set_start_value(mpcsolver.xvar[j,N], xNp1[j])
+    end
+
+    # warm start the input sequence
+    for i = 1:N
+        for j=1:2
+            set_start_value(mpcsolver.uvar[j,i], u_plan_prev[j,1])
+        end
+    end
+
+end
+
+
+
+function run_mpc(mpcsolver, xinit, xref, x_plan_prev, u_plan_prev, N)
+
+    #warm start the x/u trajectories
+    warm_start(mpcsolver, x_plan_prev, u_plan_prev, N)
+
+    #update the IPOPT parameters modelling the reference trajectory
+    for i = 1:4, j=1:N
+        JuMP.set_value(mpcsolver.xref_param[i,j], xref[i,j])
+    end
+
+    #update parametric initial state
+    for i = 1:4
+        JuMP.set_value(mpcsolver.xinit_param[i], xinit[i])
+    end
+
+    #update parametric previous input
+    for i = 1:2
+        JuMP.set_value(mpcsolver.uprev_param[i], u_plan_prev[i,1])
+    end
+
+    JuMP.optimize!(mpcsolver.model)
+    return JuMP.value.(mpcsolver.xvar), JuMP.value.(mpcsolver.uvar)
+end

--- a/settings.jl
+++ b/settings.jl
@@ -11,8 +11,8 @@ export u_initial, x_initial, horizon_length, delta_t
     delta_t = 0.1
 
 # Initial conditions
-    u_initial = [0, 0]
-    x_initial = [0, 1, 0.1, 1]
+    u_initial = [0., 0.]
+    x_initial = [0, 1., 0.1, 1.]
 
 # Control model (bicycle model) parameters
     horizon_length = 10


### PR DESCRIPTION
I implemented the following changes:

1) Extracted the build phase of the JuMP model to its own function so it only runs once.

2) Added JuMP `parameter` types to the model for the state reference, initial state and past inputs.   When calling `run_mpc`, these parameters are given updated values without need to rebuild the whole model.

IPOPT seems to run now in about 5-6 ms on my machine for most iterations after the first.   If I disable all plotting and remove the `@animate` macro in the main simulation loop then the whole thing runs in about 1 second on my laptop.   Plots (when enabled) appear to still be the same, with only very small numerical differences due to some slight changes in the way things are warmstarted.